### PR TITLE
Create svg logo Light+stroke and Dark+stroke

### DIFF
--- a/zig-logo-dark-stroke.svg
+++ b/zig-logo-dark-stroke.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 140">
+<g fill="#F7A41D">
+	<g>
+		<polygon points="46,22 28,44 19,30"/>
+		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
+		<polygon points="31,95 12,117 4,106"/>
+	</g>
+	<g>
+		<polygon points="56,22 62,36 37,44"/>
+		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
+		<polygon points="116,95 97,117 90,104"/>
+		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
+		<polygon points="150,0 52,117 3,140 101,22"/>
+	</g>
+	<g>
+		<polygon points="141,22 140,40 122,45"/>
+		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
+		<polygon points="125,95 130,110 106,117"/>
+	</g>
+</g>
+<g fill="#121212" stroke="white" stroke-width="3">
+<g>
+		<polygon points="260,22 260,37 229,40 177,40 177,22" shape-rendering="crispEdges" />
+		<polygon points="260,37 207,99 207,103 176,103 229,40 229,37"/>
+		<polygon points="261,99 261,117 176,117 176,103 206,99" shape-rendering="crispEdges" />
+	</g>
+	<rect x="272" y="22" shape-rendering="crispEdges" width="22" height="95"/>
+	<g>
+		<polygon points="394,67 394,106 376,106 376,81 360,70 346,67" shape-rendering="crispEdges"/>
+		<polygon points="360,68 376,81 346,67"/>
+		<path d="M394,106c-10.2,7.3-24,12-37.7,12c-29,0-51.1-20.8-51.1-48.3c0-27.3,22.5-48.1,52-48.1
+			c14.3,0,29.2,5.5,38.9,14l-13,15c-7.1-6.3-16.8-10-25.9-10c-17,0-30.2,12.9-30.2,29.5c0,16.8,13.3,29.6,30.3,29.6
+			c5.7,0,12.8-2.3,19-5.5L394,106z"/>
+	</g>
+</g>
+</svg>

--- a/zig-logo-light-stroke.svg
+++ b/zig-logo-light-stroke.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 140">
+<g fill="#F7A41D">
+	<g>
+		<polygon points="46,22 28,44 19,30"/>
+		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
+		<polygon points="31,95 12,117 4,106"/>
+	</g>
+	<g>
+		<polygon points="56,22 62,36 37,44"/>
+		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
+		<polygon points="116,95 97,117 90,104"/>
+		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
+		<polygon points="150,0 52,117 3,140 101,22"/>
+	</g>
+	<g>
+		<polygon points="141,22 140,40 122,45"/>
+		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
+		<polygon points="125,95 130,110 106,117"/>
+	</g>
+</g>
+<g fill="white" stroke="#121212" stroke-width="3">
+	<g>
+		<polygon points="260,22 260,37 229,40 177,40 177,22" shape-rendering="crispEdges" />
+		<polygon points="260,37 207,99 207,103 176,103 229,40 229,37"/>
+		<polygon points="261,99 261,117 176,117 176,103 206,99" shape-rendering="crispEdges" />
+	</g>
+	<rect x="272" y="22" shape-rendering="crispEdges" width="22" height="95"/>
+	<g>
+		<polygon points="394,67 394,106 376,106 376,81 360,70 346,67" shape-rendering="crispEdges"/>
+		<polygon points="360,68 376,81 346,67"/>
+		<path d="M394,106c-10.2,7.3-24,12-37.7,12c-29,0-51.1-20.8-51.1-48.3c0-27.3,22.5-48.1,52-48.1
+			c14.3,0,29.2,5.5,38.9,14l-13,15c-7.1-6.3-16.8-10-25.9-10c-17,0-30.2,12.9-30.2,29.5c0,16.8,13.3,29.6,30.3,29.6
+			c5.7,0,12.8-2.3,19-5.5L394,106z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Hi there,

Just a small PR to add new svg file.

**Summary:**
Improve README of zig repository

![bug-logo](https://user-images.githubusercontent.com/2658040/102433118-c1d89c00-4028-11eb-8cf0-05f384c82403.png)

**Problem:**
The logo is too big and ugly and the text is not clear and legible.

ref: https://github.com/ziglang/zig/pull/7470

So now the logo has no problem in both themes and looks beautiful. heart (Dark and Light)

https://github.blog/2020-12-08-new-from-universe-2020-dark-mode-github-sponsors-for-companies-and-more/#dark-mode

Regards,