### PR TITLE
generate svgs so they look better at lower resolutions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,55 @@
+const std = @import("std");
+pub fn build(b: *std.Build) void {
+    const exe = b.addExecutable(.{
+        .name = "generatesvg",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/generatesvg.zig"),
+            .target = b.graph.host,
+        }),
+    });
+
+    {
+        const install = b.addInstallArtifact(exe, .{});
+        const run = b.addRunArtifact(exe);
+        run.step.dependOn(&install.step);
+        if (b.args) |args| {
+            run.addArgs(args);
+        }
+        const run_step = b.step("generatesvg", "Generate the logo as an SVG");
+        run_step.dependOn(&run.step);
+    }
+
+    const svgs = b.step("svgs", "Generate/Install the SVG files");
+    b.getInstallStep().dependOn(svgs);
+
+    {
+        const gen = b.addRunArtifact(exe);
+        gen.addArgs(&.{ "--fill", "#f7a41d" });
+        gen.addArgs(&.{ "--width", "153" });
+        gen.addArg("--out");
+        svgs.dependOn(&b.addInstallFile(
+            gen.addOutputFileArg("zig-mark.svg"),
+            "zig-mark.svg",
+        ).step);
+    }
+    {
+        const gen = b.addRunArtifact(exe);
+        gen.addArgs(&.{ "--fill", "#121212" });
+        gen.addArgs(&.{ "--width", "153" });
+        gen.addArg("--out");
+        svgs.dependOn(&b.addInstallFile(
+            gen.addOutputFileArg("zig-mark-neg-black.svg"),
+            "zig-mark-neg-black.svg",
+        ).step);
+    }
+    {
+        const gen = b.addRunArtifact(exe);
+        gen.addArgs(&.{ "--fill", "#fff" });
+        gen.addArgs(&.{ "--width", "153" });
+        gen.addArg("--out");
+        svgs.dependOn(&b.addInstallFile(
+            gen.addOutputFileArg("zig-mark-neg-white.svg"),
+            "zig-mark-neg-white.svg",
+        ).step);
+    }
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .logo,
+    .version = "0.0.0",
+    .fingerprint = 0xe48e9a136fe6f152,
+    .minimum_zig_version = "0.14.0",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/src/generatesvg.zig
+++ b/src/generatesvg.zig
@@ -1,0 +1,210 @@
+const std = @import("std");
+
+pub fn main() !u8 {
+    var arena_instance: std.heap.ArenaAllocator = .init(std.heap.page_allocator);
+    const arena = arena_instance.allocator();
+
+    var out: ?[]const u8 = null;
+    var width: i32 = 153;
+    var square: bool = false;
+    var fill: []const u8 = "#f7a41d";
+
+    {
+        const args = try std.process.argsAlloc(arena);
+        var i: usize = 1;
+        while (i < args.len) : (i += 1) {
+            const arg = args[i];
+            if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+                std.debug.print("Usage: generatesvg  [--out OUT] [--width WIDTH] [--square] [--fill STRING]\n", .{});
+                return 0xff;
+            } else if (std.mem.eql(u8, arg, "--out")) {
+                i += 1;
+                if (i >= args.len) fatal("--out missing argument", .{});
+                out = args[i];
+            } else if (std.mem.eql(u8, arg, "--width")) {
+                i += 1;
+                if (i >= args.len) fatal("--width missing argument", .{});
+                width = std.fmt.parseInt(i32, args[i], 10) catch fatal(
+                    "invalid width '{s}'",
+                    .{args[i]},
+                );
+            } else if (std.mem.eql(u8, arg, "--square")) {
+                square = true;
+            } else if (std.mem.eql(u8, arg, "--fill")) {
+                i += 1;
+                if (i >= args.len) fatal("--fill missing argument", .{});
+                fill = args[i];
+            } else fatal("unknown cmdline option '{s}'", .{arg});
+        }
+    }
+    // ensure height/2 is an integer so we are vertically cenetered
+    const half_height: i32 = round(float(width) * 0.456);
+    const height: i32 = half_height * 2;
+
+    const stroke: i32 = round(float(width) * 0.144);
+    const top0: i32 = stroke;
+    const top1: i32 = top0 + stroke;
+    const top2: i32 = reflectInt(height, top1);
+    const top3: i32 = reflectInt(height, top0);
+
+    const file: ?std.fs.File = if (out) |o| try std.fs.cwd().createFile(o, .{}) else null;
+    defer if (file) |f| f.close();
+
+    var bw = std.io.bufferedWriter(if (file) |f| f.writer() else std.io.getStdOut().writer());
+    const writer = bw.writer();
+    try writer.print(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 {} {}\" fill=\"{s}\"",
+        .{ width, if (square) width else height, fill },
+    );
+    if (square) {
+        try writer.print(" transform=\"translate(0 {})\"", .{@divTrunc(width - height, 2)});
+    }
+    try writer.print("><g>\n", .{});
+
+    // NOTE: we draw the SVG this way so that we can customize antialiasing behavior for
+    //       orthogonal vs diagonal lines.
+
+    // The Diagonal Part of the Z
+    const slash_left0 = round(float(width) * 0.020);
+    const slash_left1 = round(float(width) * 0.332);
+    try writer.print(
+        "\t<polygon points=\"{[left0]},{[height]} {[right1]},{[top0]} {[right0]},0 {[left1]},{[bottom1]}\"/>\n",
+        .{
+            .left0 = slash_left0,
+            .left1 = slash_left1,
+            .right0 = reflectInt(width, slash_left0),
+            .right1 = reflectInt(width, slash_left1),
+            .top0 = top0,
+            .bottom1 = reflectInt(height, top0),
+            .height = height,
+        },
+    );
+
+    const dash_left0 = round(float(width) * 0.242);
+    const dash_left1 = round(float(width) * 0.369);
+
+    // The top/bottom bars of the Z
+    inline for (&.{ false, true }) |bottom| {
+        const transform: fn (i32, i32) i32 = if (bottom) reflectInt else passthruInt;
+        const right = reflectInt(width, slash_left1);
+        try writer.print(
+            "" ++
+                "\t<polygon points=\"{[x1]},{[y0]} {[x4]},{[y0]} {[x4]},{[y3]} {[x0]},{[y3]} {[x1]},{[y1]}\" shape-rendering=\"crispEdges\"/>\n" ++
+                "\t<polygon points=\"{[x1]},{[y0]} {[x3]},{[y2]} {[x0]},{[y3]}\"/>\n",
+
+            .{
+                .x0 = transform(width, dash_left0),
+                .x1 = transform(width, dash_left1),
+                .x3 = transform(width, interp(dash_left1, right, 0.2)),
+                .x4 = transform(width, right),
+                .y0 = transform(height, top0),
+                .y1 = transform(height, interp(top0, top1, 0.6)),
+                .y2 = transform(height, interp(top0, top1, 0.75)),
+                .y3 = transform(height, top1),
+            },
+        );
+    }
+    try writer.print("</g><g>\n", .{});
+
+    // The Left/Right border pieces
+    const cutout_width = float(width) * 0.061;
+    const x1: f32 = findIntersectionX(.{
+        .horizontal_line_y = top3,
+        .line_x1 = slash_left0,
+        .line_y1 = height,
+        .line_x2 = reflectInt(width, slash_left1),
+        .line_y2 = top0,
+    }) - cutout_width;
+    const x3: f32 = findIntersectionX(.{
+        .horizontal_line_y = top2,
+        .line_x1 = slash_left0,
+        .line_y1 = height,
+        .line_x2 = reflectInt(width, slash_left1),
+        .line_y2 = top0,
+    }) - cutout_width;
+
+    inline for (&.{ false, true }) |right| {
+        const transform: fn (i32, i32) i32 = if (right) reflectInt else passthruInt;
+        const transformFloat: fn (i32, f32) f32 = if (right) reflectFloat else passthruFloat;
+        try writer.print(
+            "" ++
+                "\t<polygon points=\"{[x0]},{[y0]} {[x5]},{[y0]} {[x4]},{[y1]} {[x4]},{[y2]} {[x2]},{[y2]} {[x2]},{[y3]} {[x3]d:.1},{[y3]} {[x1]d:.1},{[y4]} {[x1]d:.1},{[y5]} {[x0]},{[y5]}\" shape-rendering=\"crispEdges\"/>\n" ++
+                "\t<polygon points=\"{[x5]},{[y0]} {[x4]},{[y2]} {[x1]d:.1},{[y1]}\"/>\n" ++
+                "\t<polygon points=\"{[x3]d:.1},{[y3]} {[x1]d:.1},{[y5]} {[x0]},{[y4]}\"/>\n",
+            .{
+                .x0 = transform(width, 0),
+                .x1 = transformFloat(width, x1),
+                .x2 = transform(width, stroke),
+                .x3 = transformFloat(width, x3),
+                .x4 = transform(width, dash_left0 - round(cutout_width)),
+                .x5 = transform(width, dash_left1 - round(cutout_width)),
+
+                .y0 = transform(height, top0),
+                .y1 = transform(height, interp(top0, top1, 0.4)),
+                .y2 = transform(height, top1),
+                .y3 = transform(height, top2),
+                .y4 = transform(height, interp(top2, top3, 0.4)),
+                .y5 = transform(height, top3),
+            },
+        );
+        try writer.print("</g><g>\n", .{});
+    }
+    try writer.print("</g></svg>\n", .{});
+    try bw.flush();
+    return 0;
+}
+
+fn findIntersectionX(args: struct {
+    horizontal_line_y: i32,
+    line_x1: i32,
+    line_y1: i32,
+    line_x2: i32,
+    line_y2: i32,
+}) f32 {
+    if (args.line_y1 == args.line_y2) return if (args.line_y1 == args.horizontal_line_y)
+        float(args.line_x1)
+    else
+        float(@min(args.line_x1, args.line_x2) - 1);
+
+    const slope = float(args.line_y2 - args.line_y1) / float(args.line_x2 - args.line_x1);
+    const y_intercept = float(args.line_y1) - slope * float(args.line_x1);
+    const intersection_x = (float(args.horizontal_line_y) - y_intercept) / slope;
+    const min_x = @min(args.line_x1, args.line_x2);
+    const max_x = @max(args.line_x1, args.line_x2);
+    if (intersection_x >= float(min_x) and intersection_x <= float(max_x)) {
+        return intersection_x;
+    } else {
+        return float(@min(args.line_x1, args.line_x2) - 1);
+    }
+}
+
+fn float(i: i32) f32 {
+    return @floatFromInt(i);
+}
+fn round(f: f32) i32 {
+    return @intFromFloat(@round(f));
+}
+fn interp(a: i32, b: i32, ratio: f32) i32 {
+    return a + round(float(b - a) * ratio);
+}
+
+fn passthruInt(size: i32, i: i32) i32 {
+    _ = size;
+    return i;
+}
+fn reflectInt(size: i32, i: i32) i32 {
+    return size - i;
+}
+
+fn passthruFloat(size: i32, f: f32) f32 {
+    _ = size;
+    return f;
+}
+fn reflectFloat(size: i32, f: f32) f32 {
+    return @as(f32, @floatFromInt(size)) - f;
+}
+
+fn fatal(comptime fmt: []const u8, args: anytype) noreturn {
+    std.log.err(fmt, args);
+    std.process.exit(0xff);
+}

--- a/zig-mark-neg-black.svg
+++ b/zig-mark-neg-black.svg
@@ -1,21 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140">
-<g fill="#121212">
-	<g>
-		<polygon points="46,22 28,44 19,30"/>
-		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
-		<polygon points="31,95 12,117 4,106"/>
-	</g>
-	<g>
-		<polygon points="56,22 62,36 37,44"/>
-		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
-		<polygon points="116,95 97,117 90,104"/>
-		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
-		<polygon points="150,0 52,117 3,140 101,22"/>
-	</g>
-	<g>
-		<polygon points="141,22 140,40 122,45"/>
-		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
-		<polygon points="125,95 130,110 106,117"/>
-	</g>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140" fill="#121212"><g>
+	<polygon points="3,140 102,22 150,0 51,118"/>
+	<polygon points="56,22 102,22 102,44 37,44 56,35" shape-rendering="crispEdges"/>
+	<polygon points="56,22 65,39 37,44"/>
+	<polygon points="97,118 51,118 51,96 116,96 97,105" shape-rendering="crispEdges"/>
+	<polygon points="97,118 88,101 116,96"/>
+</g><g>
+	<polygon points="0,22 47,22 28,31 28,44 22,44 22,96 30.6,96 12.1,105 12.1,118 0,118" shape-rendering="crispEdges"/>
+	<polygon points="47,22 28,44 12.1,31"/>
+	<polygon points="30.6,96 12.1,118 0,105"/>
+</g><g>
+	<polygon points="153,118 106,118 125,109 125,96 131,96 131,44 122.4,44 140.9,35 140.9,22 153,22" shape-rendering="crispEdges"/>
+	<polygon points="106,118 125,96 140.9,109"/>
+	<polygon points="122.4,44 140.9,22 153,35"/>
+</g><g>
+</g></svg>

--- a/zig-mark-neg-white.svg
+++ b/zig-mark-neg-white.svg
@@ -1,21 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140">
-<g fill="#fff">
-	<g>
-		<polygon points="46,22 28,44 19,30"/>
-		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
-		<polygon points="31,95 12,117 4,106"/>
-	</g>
-	<g>
-		<polygon points="56,22 62,36 37,44"/>
-		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
-		<polygon points="116,95 97,117 90,104"/>
-		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
-		<polygon points="150,0 52,117 3,140 101,22"/>
-	</g>
-	<g>
-		<polygon points="141,22 140,40 122,45"/>
-		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
-		<polygon points="125,95 130,110 106,117"/>
-	</g>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140" fill="#fff"><g>
+	<polygon points="3,140 102,22 150,0 51,118"/>
+	<polygon points="56,22 102,22 102,44 37,44 56,35" shape-rendering="crispEdges"/>
+	<polygon points="56,22 65,39 37,44"/>
+	<polygon points="97,118 51,118 51,96 116,96 97,105" shape-rendering="crispEdges"/>
+	<polygon points="97,118 88,101 116,96"/>
+</g><g>
+	<polygon points="0,22 47,22 28,31 28,44 22,44 22,96 30.6,96 12.1,105 12.1,118 0,118" shape-rendering="crispEdges"/>
+	<polygon points="47,22 28,44 12.1,31"/>
+	<polygon points="30.6,96 12.1,118 0,105"/>
+</g><g>
+	<polygon points="153,118 106,118 125,109 125,96 131,96 131,44 122.4,44 140.9,35 140.9,22 153,22" shape-rendering="crispEdges"/>
+	<polygon points="106,118 125,96 140.9,109"/>
+	<polygon points="122.4,44 140.9,22 153,35"/>
+</g><g>
+</g></svg>

--- a/zig-mark.svg
+++ b/zig-mark.svg
@@ -1,21 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140">
-<g fill="#f7a41d">
-	<g>
-		<polygon points="46,22 28,44 19,30"/>
-		<polygon points="46,22 33,33 28,44 22,44 22,95 31,95 20,100 12,117 0,117 0,22" shape-rendering="crispEdges"/>
-		<polygon points="31,95 12,117 4,106"/>
-	</g>
-	<g>
-		<polygon points="56,22 62,36 37,44"/>
-		<polygon points="56,22 111,22 111,44 37,44 56,32" shape-rendering="crispEdges"/>
-		<polygon points="116,95 97,117 90,104"/>
-		<polygon points="116,95 100,104 97,117 42,117 42,95" shape-rendering="crispEdges"/>
-		<polygon points="150,0 52,117 3,140 101,22"/>
-	</g>
-	<g>
-		<polygon points="141,22 140,40 122,45"/>
-		<polygon points="153,22 153,117 106,117 120,105 125,95 131,95 131,45 122,45 132,36 141,22" shape-rendering="crispEdges"/>
-		<polygon points="125,95 130,110 106,117"/>
-	</g>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 153 140" fill="#f7a41d"><g>
+	<polygon points="3,140 102,22 150,0 51,118"/>
+	<polygon points="56,22 102,22 102,44 37,44 56,35" shape-rendering="crispEdges"/>
+	<polygon points="56,22 65,39 37,44"/>
+	<polygon points="97,118 51,118 51,96 116,96 97,105" shape-rendering="crispEdges"/>
+	<polygon points="97,118 88,101 116,96"/>
+</g><g>
+	<polygon points="0,22 47,22 28,31 28,44 22,44 22,96 30.6,96 12.1,105 12.1,118 0,118" shape-rendering="crispEdges"/>
+	<polygon points="47,22 28,44 12.1,31"/>
+	<polygon points="30.6,96 12.1,118 0,105"/>
+</g><g>
+	<polygon points="153,118 106,118 125,109 125,96 131,96 131,44 122.4,44 140.9,35 140.9,22 153,22" shape-rendering="crispEdges"/>
+	<polygon points="106,118 125,96 140.9,109"/>
+	<polygon points="122.4,44 140.9,22 153,35"/>
+</g><g>
+</g></svg>


### PR DESCRIPTION
SVG's work well for graphics at higher resolutions but start to break down at lower resolutions.  For situations like icons, resolutions can get quite small (i.e. 16x16). As far as I know it's not possible to create a single SVG that will look good at such a low resolution and at the same time also look good at lower neighboring resolutions (i.e. 17x17, 18x18, etc).

To address this, I've encoded the Zig logo as a Zig program that will generates an SVG for any given size. In creating this program I opted to make things symmetrical. For example, the top/bottom margins now match, the top/bottom part of the "Z" are now the same height, the gap between the side components and the center Z is now the same and the angles are more consistent (topleft angle matches bottomright and bottomleft angle matches topright). After making things symmetrical the diagonal looked a bit thicker to me than it was before so I steepend the angle to fix that.

You can update the svg's in the repo with `zig build svgs --prefix .`.  If we want to go in this "generate svg files" direction we should probably enhance this to generate the other SVG's as well.

I used https://svg2ico.com/ to generate 16x16 icon files from the SVGS, the first is using the original SVG before this PR and the second is using an SVG generated with a width of 16, i.e.:
```
>zig build generatesvg -- --width 16 --square
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="#f7a41d" transform="translate(0 1)"><g>
	<polygon points="0,14 11,2 16,0 5,12"/>
	<polygon points="6,2 11,2 11,4 4,4 6,3" shape-rendering="crispEdges"/>
	<polygon points="6,2 7,4 4,4"/>
	<polygon points="10,12 5,12 5,10 12,10 10,11" shape-rendering="crispEdges"/>
	<polygon points="10,12 9,10 12,10"/>
</g><g>
	<polygon points="0,2 5,2 3,3 3,4 2,4 2,10 2.7,10 0.9,11 0.9,12 0,12" shape-rendering="crispEdges"/>
	<polygon points="5,2 3,4 0.9,3"/>
	<polygon points="2.7,10 0.9,12 0,11"/>
</g><g>
	<polygon points="16,12 11,12 13,11 13,10 14,10 14,4 13.3,4 15.1,3 15.1,2 16,2" shape-rendering="crispEdges"/>
	<polygon points="11,12 13,10 15.1,11"/>
	<polygon points="13.3,4 15.1,2 16,3"/>
</g><g>
</g></svg>

```

# Generated 16x16 .ico file before this PR

![image](https://github.com/user-attachments/assets/484880c4-cbc9-4ada-b728-64d7c9686d1e)

# Generated 16x16 .ico file after this

![image](https://github.com/user-attachments/assets/b785834d-ced7-4bdb-917b-b4a0c9fe3620)
